### PR TITLE
Fix 'int' object is not callable

### DIFF
--- a/telemongo/telemongo.py
+++ b/telemongo/telemongo.py
@@ -134,7 +134,7 @@ class MongoSession(MemorySession):
                                pts=state.pts,
                                qts=state.qts,
                                date=state.date.timestamp(),
-                               seq=state.seq()).save()
+                               seq=state.seq).save()
 
     def save(self):
         pass

--- a/telemongo/telemongo.py
+++ b/telemongo/telemongo.py
@@ -130,7 +130,7 @@ class MongoSession(MemorySession):
 
     def set_update_state(self, entity_id, state):
         with switch_db(UpdateState, self.database) as _UpdateState:
-            return _UpdateState(entity_id=entity_id,
+            return _UpdateState(id=entity_id,
                                pts=state.pts,
                                qts=state.qts,
                                date=state.date.timestamp(),


### PR DESCRIPTION
When `Telethon` calls `client.disconnect`, Telemongo throws the following exception:

```
File "/../.venv/lib/python3.10/site-packages/telemongo/telemongo.py", line 137, in set_update_state
    seq=state.seq()).save()
TypeError: 'int' object is not callable
```

This PR fixes it by not calling the `state.seq` since [it is a `int`](https://github.com/watzon/telethon-session-mongo/blob/fa03d90850dfabcbb2d39e36786b1a8dbbd90857/telemongo/telemongo.py#L41).

https://github.com/watzon/telethon-session-mongo/blob/fa03d90850dfabcbb2d39e36786b1a8dbbd90857/telemongo/telemongo.py#L41

Also, on fixing issue with `seq`, realized that `UpdateState` does not have a property `entity_id`. Fixed that by replacing it with `id`.